### PR TITLE
HUB-971: Update tests to use the new "about documents" page

### DIFF
--- a/backstop_data/engine_scripts/puppeteer/clearCookies.js
+++ b/backstop_data/engine_scripts/puppeteer/clearCookies.js
@@ -1,9 +1,9 @@
 module.exports = async (page, scenario) => {
-  console.log("CLEARING COOKIES");
+    console.log("CLEARING COOKIES");
 
-  const cookies = await page.cookies(scenario.url);
+    const cookies = await page.cookies(scenario.url);
 
-  await Promise.all(
-    cookies.map(async (cookie) => { page.deleteCookie(cookie) })
-  );
+    await Promise.all(
+        cookies.map(async (cookie) => { page.deleteCookie(cookie) })
+    );
 };

--- a/backstop_data/engine_scripts/puppeteer/documentSelectionHelper.js
+++ b/backstop_data/engine_scripts/puppeteer/documentSelectionHelper.js
@@ -1,20 +1,11 @@
 module.exports = async (page, scenario) => {
-    if (scenario.hasOwnProperty('selectDocuments')) {
-        await page.goto(scenario.selectDocuments)
-
-        await page.waitFor('#select_documents_form_has_valid_passport')
-        await page.waitFor('#select_documents_form_has_driving_license')
-        await page.waitFor('#select_documents_form_has_phone_can_app')
-        await page.waitFor('#select_documents_form_has_credit_card')
-
-        await page.click('#select_documents_form_has_valid_passport')
-        await page.click('#select_documents_form_has_driving_license')
-        await page.click('#select_documents_form_has_phone_can_app')
-        await page.click('#select_documents_form_has_credit_card')
+    if (scenario.selectDocuments) {
+        let frontendDomain = process.env.VERIFY_FRONTEND_DOMAIN
+        await page.goto(frontendDomain + "/about-documents")
 
         await Promise.all([
-          page.waitForNavigation(),
-          page.click('#next-button')
+            page.waitForNavigation(),
+            page.click('#next-button')
         ]);
     }
 }

--- a/backstop_data/engine_scripts/puppeteer/onReady.js
+++ b/backstop_data/engine_scripts/puppeteer/onReady.js
@@ -1,7 +1,7 @@
 module.exports = async (page, scenario, vp) => {
-  console.log('SCENARIO > ' + scenario.label);
-  await require('./submitFormHelper')(page, scenario);
-  await require('./sortAboutCompanies')(page, scenario);
-  await require('./sortChooseACertifiedCompany')(page, scenario);
-  await require('./sortSignIn')(page, scenario);
+    console.log('SCENARIO > ' + scenario.label);
+    await require('./submitFormHelper')(page, scenario);
+    await require('./sortAboutCompanies')(page, scenario);
+    await require('./sortChooseACertifiedCompany')(page, scenario);
+    await require('./sortSignIn')(page, scenario);
 };

--- a/backstop_data/engine_scripts/puppeteer/previouslySignedInWithIdp.js
+++ b/backstop_data/engine_scripts/puppeteer/previouslySignedInWithIdp.js
@@ -23,14 +23,14 @@ module.exports = async (page, scenario) => {
             page.click('#agree')
         ])
 
-         await Promise.all([
-             page.waitForNavigation(),
-             page.click('#logout')
-         ])
+        await Promise.all([
+            page.waitForNavigation(),
+            page.click('#logout')
+        ])
 
-         await Promise.all([
-             page.waitForNavigation(),
-             page.click('.button.get-started')
-         ])
+        await Promise.all([
+            page.waitForNavigation(),
+            page.click('.button.get-started')
+        ])
     }
 }

--- a/backstop_data/engine_scripts/puppeteer/sortSignIn.js
+++ b/backstop_data/engine_scripts/puppeteer/sortSignIn.js
@@ -75,7 +75,7 @@ module.exports = async (page, scenario) => {
 
     async function resolveCompanyInnerHtml(arrayOfInnersWithSortAttribute) {
         let innerHtmlValues = [];
-        for (var i = 0; i < arrayOfInnersWithSortAttribute.length; i++) {
+        for (let i = 0; i < arrayOfInnersWithSortAttribute.length; i++) {
             const htmlHandle = await arrayOfInnersWithSortAttribute[i][0].evaluateHandle(div => div.innerHTML);
             innerHtmlValues.push(await htmlHandle.jsonValue());
         }
@@ -83,7 +83,7 @@ module.exports = async (page, scenario) => {
     }
 
     async function updatePageHtml(companyInners, htmlValues) {
-        for (var i = 0; i < companyInners.length; i++) {
+        for (let i = 0; i < companyInners.length; i++) {
             await companyInners[i].evaluate((companyInner, htmlValue) => {
                 companyInner.innerHTML = htmlValue;
             }, htmlValues[i])

--- a/backstop_data/engine_scripts/puppeteer/submitFormHelper.js
+++ b/backstop_data/engine_scripts/puppeteer/submitFormHelper.js
@@ -1,11 +1,11 @@
 module.exports = async (page, scenario) => {
-  if (scenario.submitForm) {
-    await Promise.all([
-      page.waitForNavigation(),
-      page.$eval(
-        'main form',
-        form => form.submit(),
-      ),
-    ]);
-  }
+    if (scenario.submitForm) {
+        await Promise.all([
+            page.waitForNavigation(),
+            page.$eval(
+                'main form',
+                form => form.submit(),
+            ),
+        ]);
+    }
 };

--- a/config.js
+++ b/config.js
@@ -1,99 +1,93 @@
-var testRpUrl = process.env.VERIFY_TEST_RP_URL || 'http://localhost:50130/test-rp'
-var frontendDomain = process.env.VERIFY_FRONTEND_DOMAIN || 'http://localhost:50300'
+let testRpUrl = process.env.VERIFY_TEST_RP_URL || 'http://localhost:50130/test-rp'
+let frontendDomain = process.env.VERIFY_FRONTEND_DOMAIN || 'http://localhost:50300'
 
 module.exports = {
-  "id": "backstop_verify",
-  "viewports": [
-    {
-      "label": "phone",
-      "width": 320,
-      "height": 480
+    "id": "backstop_verify",
+    "viewports": [
+        {
+            "label": "phone",
+            "width": 320,
+            "height": 480
+        },
+        {
+            "label": "tablet",
+            "height": 768,
+            "width": 1024
+        },
+        {
+            "label": "desktop",
+            "width": 1366,
+            "height": 768
+        }
+    ],
+    "misMatchThreshold": 0,
+    "requireSameDimensions": false,
+    "onBeforeScript": "onBefore.js",
+    "onReadyScript": "onReady.js",
+    "scenarios": [
+        {
+            "label": "Start",
+            "url": frontendDomain + "/start",
+            "getSession": testRpUrl,
+        },
+        {
+            "label": "Start with previous IDP",
+            "url": frontendDomain + "/start",
+            "getSession": testRpUrl,
+            "previouslySignedInWithIDP": frontendDomain + "/sign-in",
+        },
+        {
+            "label": "About",
+            "url": frontendDomain + "/about",
+            "getSession": testRpUrl,
+            "sortAboutCompanies": true
+        },
+        {
+            "label": "Will it work for me",
+            "url": frontendDomain + "/will-it-work-for-me",
+            "getSession": testRpUrl,
+        },
+        {
+            "label": "Will it work for me - validation",
+            "url": frontendDomain + "/will-it-work-for-me",
+            "getSession": testRpUrl,
+            "submitForm": true
+        },
+        {
+            "label": "About documents",
+            "url": frontendDomain + "/about-documents",
+            "getSession": testRpUrl,
+        },
+        {
+            "label": "Choose a certified company",
+            "url": frontendDomain + "/choose-a-certified-company",
+            "getSession": testRpUrl,
+            "selectDocuments": true,
+            "sortChooseACertifiedCompany": true
+        },
+        {
+            "label": "About company",
+            "url": frontendDomain + "/choose-a-certified-company/stub-idp-demo-one",
+            "getSession": testRpUrl,
+        },
+        {
+            "label": "Sign in",
+            "url": frontendDomain + "/sign-in",
+            "getSession": testRpUrl,
+            "sortSignIn": true
+        },
+    ],
+    "paths": {
+        "bitmaps_reference": "backstop_data/bitmaps_reference",
+        "bitmaps_test": "backstop_data/bitmaps_test",
+        "engine_scripts": "backstop_data/engine_scripts/puppeteer",
+        "html_report": "backstop_data/html_report"
     },
-    {
-      "label": "tablet",
-      "height": 768,
-      "width": 1024
+    "report": ["browser"],
+    "engine": "puppeteer",
+    "engineOptions": {
+        "args": ["--no-sandbox"],
     },
-    {
-      "label": "desktop",
-      "width": 1366,
-      "height": 768
-    }
-  ],
-  "misMatchThreshold": 0,
-  "requireSameDimensions": false,
-  "onBeforeScript": "onBefore.js",
-  "onReadyScript": "onReady.js",
-  "scenarios": [
-    {
-      "label": "Start",
-      "url": frontendDomain + "/start",
-      "getSession": testRpUrl,
-    },
-    {
-      "label": "Start with previous IDP",
-      "url": frontendDomain + "/start",
-      "getSession": testRpUrl,
-      "previouslySignedInWithIDP": frontendDomain + "/sign-in",
-    },
-    {
-      "label": "About",
-      "url": frontendDomain + "/about",
-      "getSession": testRpUrl,
-      "sortAboutCompanies": true
-    },
-    {
-      "label": "Will it work for me",
-      "url": frontendDomain + "/will-it-work-for-me",
-      "getSession": testRpUrl,
-    },
-    {
-      "label": "Will it work for me - validation",
-      "url": frontendDomain + "/will-it-work-for-me",
-      "getSession": testRpUrl,
-      "submitForm": true
-    },
-    {
-      "label": "Select documents",
-      "url": frontendDomain + "/select-documents",
-      "getSession": testRpUrl,
-    },
-    {
-      "label": "Select documents - validation",
-      "url": frontendDomain + "/select-documents",
-      "getSession": testRpUrl,
-      "submitForm": true
-    },
-    {
-      "label": "Choose a certified company",
-      "url": frontendDomain + "/choose-a-certified-company",
-      "getSession": testRpUrl,
-      "selectDocuments": frontendDomain + "/select-documents",
-      "sortChooseACertifiedCompany": true
-    },
-    {
-      "label": "About company",
-      "url": frontendDomain + "/choose-a-certified-company/stub-idp-demo-one",
-      "getSession": testRpUrl,
-    },
-    {
-      "label": "Sign in",
-      "url": frontendDomain + "/sign-in",
-      "getSession": testRpUrl,
-      "sortSignIn": true
-    },
-  ],
-  "paths": {
-    "bitmaps_reference": "backstop_data/bitmaps_reference",
-    "bitmaps_test": "backstop_data/bitmaps_test",
-    "engine_scripts": "backstop_data/engine_scripts/puppeteer",
-    "html_report": "backstop_data/html_report"
-  },
-  "report": ["browser"],
-  "engine": "puppeteer",
-  "engineOptions": {
-    "args": ["--no-sandbox"],
-  },
-  "debug": false,
-  "debugWindow": false
+    "debug": false,
+    "debugWindow": false
 }

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+environment=local
+reset_state=false
+
+while getopts "ce:" arg; do
+  case $arg in
+    e)
+      environment=$OPTARG
+      ;;
+    c)
+      reset_state=true
+      ;;
+    *)
+      echo "Use '-e' to set environment to local|staging|integration and '-c' to reset state"
+      exit 1
+      ;;
+  esac
+done
+
+case $environment in
+  local)
+    test_rp_url=http://localhost:50130/test-rp
+    frontend_domain=http://localhost:50300
+    ;;
+  staging)
+    test_rp_url=https://test-rp-staging.cloudapps.digital/test-rp
+    frontend_domain=https://www.staging.signin.service.gov.uk
+    ;;
+  integration)
+    test_rp_url=https://test-rp-integration.cloudapps.digital/test-rp
+    frontend_domain=https://www.integration.signin.service.gov.uk
+    ;;
+  *)
+    echo "Invalid environment: ${environment}"
+    exit 1
+    ;;
+esac
+
+if [[ $reset_state == "true" ]]; then
+  echo "Resetting state..."
+  rm -Rf backstop_data/bitmaps_reference
+  rm -Rf backstop_data/bitmaps_test
+  rm -Rf backstop_data/html_report
+fi
+
+echo "Running tests against ${environment}"
+npm install --silent
+VERIFY_TEST_RP_URL=$test_rp_url VERIFY_FRONTEND_DOMAIN=$frontend_domain npm run test


### PR DESCRIPTION
The "select documents" page has been replaced with the new page. In order for the IDP picker to work, we still need to click the button on the static "about documents" page as that fakes the document selections. This will be removed in a future frontend PR and the tests will have to be updated again.

Additional improvements:

  - Add a script to easily run tests against different environments

  - Make indentation the same across all files. Some files in the project were indented with 2 spaces and some with 4. This commit makes all files use 4 spaces for consistency.

  - Use 'let' instead of 'var' in all places