### PR TITLE
HUB-1078: Filter out null buttons when sorting companies

### DIFF
--- a/backstop_data/engine_scripts/puppeteer/onBefore.js
+++ b/backstop_data/engine_scripts/puppeteer/onBefore.js
@@ -1,4 +1,4 @@
-module.exports = async (page, scenario, vp) => {
+module.exports = async (page, scenario) => {
     await require('./clearCookies')(page, scenario);
     await require('./getSession')(page, scenario);
     await require('./previouslySignedInWithIdp')(page, scenario);

--- a/backstop_data/engine_scripts/puppeteer/previouslySignedInWithIdp.js
+++ b/backstop_data/engine_scripts/puppeteer/previouslySignedInWithIdp.js
@@ -1,6 +1,7 @@
 module.exports = async (page, scenario) => {
-    if (scenario.hasOwnProperty('previouslySignedInWithIDP')) {
-        await page.goto(scenario.previouslySignedInWithIDP);
+    if (scenario.previouslySignedInWithIDP) {
+        let frontendDomain = process.env.VERIFY_FRONTEND_DOMAIN
+        await page.goto(frontendDomain + "/sign-in");
 
         await Promise.all([
             page.waitForNavigation(),

--- a/backstop_data/engine_scripts/puppeteer/sortAboutCompanies.js
+++ b/backstop_data/engine_scripts/puppeteer/sortAboutCompanies.js
@@ -10,7 +10,7 @@ module.exports = async (page, scenario) => {
         // test runs. Using the image alt text (which is the name of the IDP) works. We need to resolve the alt text
         // before sorting as the sort doesn't like async stuff.
         const companyListItemsWithResolvedImgAlt = await Promise.all(companyListItems.map(async listItem => {
-            let image = await listItem.$("img");
+            let image = await listItem.$('img');
             let imageAlt = await image.evaluate(image => { return image.alt });
             return [listItem, imageAlt];
         }));

--- a/backstop_data/engine_scripts/puppeteer/sortChooseACertifiedCompany.js
+++ b/backstop_data/engine_scripts/puppeteer/sortChooseACertifiedCompany.js
@@ -9,10 +9,15 @@ module.exports = async (page, scenario) => {
         // We need to sort the companies by some criteria - doesn't really matter what as long as it's consistent between
         // test runs. Using the button name (which is the name of the IDP) works. We need to resolve the name
         // before sorting as the sort doesn't like async stuff.
-        const companyFormsWithResolvedButtonName = await Promise.all(companyForms.map(async form => {
+        const formsWithButtons = (await Promise.all(companyForms.map(async form => {
             let button = await form.$('button');
+            return [form, button]
+        }))).filter(formWithButton => formWithButton[1] != null);
+
+        const companyFormsWithResolvedButtonName = await Promise.all(formsWithButtons.map(async formWithButton => {
+            let button = formWithButton[1];
             let buttonName = await button.evaluate(button => { return button.name });
-            return [form, buttonName];
+            return [formWithButton[0], buttonName];
         }));
 
         // Sort by the name we just retrieved

--- a/config.js
+++ b/config.js
@@ -34,7 +34,7 @@ module.exports = {
             label: "Start with previous IDP",
             url: frontendDomain + "/start",
             getSession: testRpUrl,
-            previouslySignedInWithIDP: frontendDomain + "/sign-in",
+            previouslySignedInWithIDP: true,
         },
         {
             label: "About",


### PR DESCRIPTION
Some buttons are null and cause errors when running the tests. Filtering them out resolves the issue and allows for correct sorting.